### PR TITLE
1 slamfire junk shotguns crafting error

### DIFF
--- a/mods/Craftline/media/scripts/Recipes_Guns.txt
+++ b/mods/Craftline/media/scripts/Recipes_Guns.txt
@@ -39,10 +39,9 @@ module Base
 
 	recipe Craft Slamfire Junk Pipe Shotgun
 	{
-		MetalPipe/MetalBar,
+		MetalPipe/MetalBar=3,
 		Screws/Nails=5,
-		MetalBar/MetalPipe/WoodenStick,
-		Plank/MetalPipe,
+		Plank,
 		DuctTape=2,
 		BlowTorch=3,
 		LeatherStrips/RippedSheets/DenimStrips=1,
@@ -58,10 +57,9 @@ module Base
 
 	recipe Craft Junk Stapler Shotgun
 	{
-		MetalPipe/MetalBar,
+		MetalPipe/MetalBar = 3,
 		Screws/Nails=5,
-		MetalBar/MetalPipe/WoodenStick,
-		Plank/MetalPipe,
+		Plank,
 		DuctTape=2,
 		BlowTorch=3,
 		LeatherStrips/RippedSheets/DenimStrips=1,


### PR DESCRIPTION
Updates junk shotgun recipes to fix the error where a shotgun could be crafted but would result in an error due to how PZ handles recipe lists.