### PR TITLE
QueueLine and LogLine patches

### DIFF
--- a/mods/DL_LogLine/media/lua/shared/LogLineUtils.lua
+++ b/mods/DL_LogLine/media/lua/shared/LogLineUtils.lua
@@ -118,7 +118,7 @@ function LogLineUtils.ContainerToLogStr(container)
 
             if instanceof(parent, "IsoPlayer") then
                 if parent:getSteamID() then
-                    local steamIDString = SteamUtils.convertSteamIDToString(parent:getSteamID());
+                    local steamIDString = parent:getSteamID();
                     return string.format("%s (SID: %s)", parent:getUsername(), steamIDString);
                 end
 

--- a/mods/DL_QueueLine/media/lua/client/QueueLine_Client.lua
+++ b/mods/DL_QueueLine/media/lua/client/QueueLine_Client.lua
@@ -6,6 +6,8 @@ if isServer() then return end;
 
 WRC = WRC or {};
 WRC.Meta = WRC.Meta or {};
+WRC.SpecialCommands = WRC.SpecialCommands or {};
+WRC.Commands = WRC.Commands or {};
 
 WRC.SpecialCommands["/queuelang"] = {
     handler = "QueueLanguage",

--- a/mods/DL_QueueLine/mod.info
+++ b/mods/DL_QueueLine/mod.info
@@ -3,4 +3,4 @@ id=DL_QueueLine
 description=Allows offline issuing of character features to allow for timezone differences.
 require=WastelandsRpChat
 poster=poster.png
-loadModAfter=DL_LogLine
+loadModAfter=DL_LogLine;WastelandsRpChat


### PR DESCRIPTION
Because I forgot to fix this before pushing - 
QueueLine - added further checks for WRC to stop the script thinking WRC.SpecialCommands is invalid.
LogLine - reverted SteamUtils patch as that was not being registered on server.
